### PR TITLE
Standardize naming of figures and tables

### DIFF
--- a/paper/chunk-options-paper.R
+++ b/paper/chunk-options-paper.R
@@ -27,12 +27,12 @@ fig_supp_cellcycle <- "S10"
 fig_supp_subsample <- "S11"
 
 # Numbering tables
-table_qualitycell <- "Table 1"
+table_qualitycell <- "1"
 
 # Numbering for supplementary tables
-table_supp_collection <- "Sup. Table 1"
-table_noisygene <- "Sup. Table 2"
-table_GO <- "Sup. Table 3"
+table_supp_collection <- "S1"
+table_noisygene <- "S2"
+table_GO <- "S3"
 
 # Import data
 anno_filter <- read.table("../data/annotation-filter.txt", header = TRUE,

--- a/paper/legends.Rmd
+++ b/paper/legends.Rmd
@@ -63,49 +63,49 @@ List of high quality single cell samples. There are total `r nrow(anno_filter)` 
 
 ## Supplemental Figures
 
-### Sup. Figure 1. Removal of low quality samples using cutoffs.
+### Figure `r fig_supp_qc`. Removal of low quality samples using cutoffs.
 Violin plots of the total read-counts of ERCC spike-in controls in (A) and the total molecule-counts in (B) in single cell samples.
 The three colors represent the three individuals (NA19098 in red, NA19101 in green, and NA19239 in blue).
 Data from different C1 replicates is plotted in different shapes.
 (C-F) Density plots of the distributions of the total mapped reads in (C), the percentage of unmapped reads in (D), the percentage of ERCC reads in (E), and the number of detected genes in (F).
 The dash lines indicate the cutoffs based on the 95 percentile of the samples with no cells (green).
 
-### Sup. Figure 2. Removal of potential multi-cell samples.
+### Figure `r fig_supp_lda`. Removal of potential multi-cell samples.
 Scatterplots of the three groups of samples (no cell in green, single-cell in orange, and two or more cells in purple) before in (A) and after in (B) the linear discriminant analysis (LDA) using sample concentration of cDNA amplicons (ng/ul) and the number of detected genes.
 (C and D) Similarly, LDA was performed to identify potential multi-cell samples using the read-to-molecule conversion efficiency, computed from total molecule counts divided by total read counts per sample, of endogenous genes and ERCC spike-in controls.
 Scatterplots of before and after the LDA in (C) and (D), respectively.
 The numbers indicate the cell numbers observed in each capture site on C1 plate.
 
-### Sup. Figure 3. Variance component analysis of per-gene expression profile.
+### Figure `r fig_supp_variance`. Variance component analysis of per-gene expression profile.
 Box plots of the proportion of variance due to individual effect or batch effect from different C1 replicates. 
 Endogenous genes are shown in (A) and the ERCC spike-in controls in (B).
 
-### Sup. Figure 4. The gene-specific dropout rate
+### Figure `r fig_supp_dropout`. The gene-specific dropout rate
 The gene-specific dropout rate (the proportion of cells in which the gene is undetected) and its relationship with log10 mean expression in (A), with log10 variance of expression in (B), and with the CV in (C) of the cells in which the gene is expressed (cells that were quantified by one or more molecule counts of the given gene).
 Each point represents a gene, and red lines indicate the predicted values using locally weighted scatterplot smooth (LOESS).
 
-### Sup. Figure 5. Permutation-based *P*-value.
+### Figure `r fig_supp_permutation`. Permutation-based *P*-value.
 \(A\) Histogram of empirical *P*-values based on `r format(sum(grepl("ENSG", rownames(molecules_filter))), big.mark = ",")` permutations.
 (B) -log10 empirical *P*-values are plotted against average gene expression levels. 
 Blue line indicates the predicted -log10 *P*-values using locally weighted scatterplot smooth (LOESS).
 (C) Median of Absolute Deviation (MAD) of genes versus average gene expression levels.
 LOESS was also used to depict predicted MAD values (green line).
 
-### Sup. Figure 6. Cell-to-cell variation of pluripotency genes.  
+### Figure `r fig_supp_plurigene` Cell-to-cell variation of pluripotency genes.
 Density plots of the distribution of log2 gene expression of key pluripotent genes across all single cells by individual.
 The peaks with lower gene expression values (log2 around 4) represent the cells in which the gene is undetected.
 The three colors represent the three individuals (NA19098 is in red, NA19101 in green, and NA19239 in blue).
 
-### Sup. Figure 7. Proposed study design for scRNA-seq on C1.
+### Figure `r fig_supp_design`. Proposed study design for scRNA-seq on C1.
 \(A\) A balanced study design consisting of multiple individuals within a C1 plate and multiple C1 replicates to fully capture the batch effect across C1 plates and further retrieve the maximum amount of biological information.
 (B) The correct identity of each single cell sample was determined by examining the SNPs present in their RNA sequencing reads.
 
-### Sup. Figure 8. The proportion of genes detected in single cell samples.
+### Figure `r fig_supp_proportion`. The proportion of genes detected in single cell samples.
 Violin plots of the proportion of genes detected, computed by the total number of detected genes in each single cell divided by the total number of genes detected across all single cells, before in (A) and after in (B) the removal of genes with low expressions (see Method).
 The three colors represent the three individuals (NA19098 is in red, NA19101 in green, and NA19239 in blue).
 Data from different C1 replicates is plotted in different shapes.
 
-### Sup. Figure 9. Coefficients of variation (CV) before and after adjusting for gene mean abundance.
+### Figure `r fig_supp_CV`. Coefficients of variation (CV) before and after adjusting for gene mean abundance.
 (A-C) CV plotted against average molecule counts across all cells for each individual. 
 Grey points represent endogenous genes, and blue points represent ERCC spike-in controls.
 The curves indicate the expected CV under three different scenarios. 

--- a/paper/legends.Rmd
+++ b/paper/legends.Rmd
@@ -116,15 +116,15 @@ Yellow curve depicts the expected CVs of an over-dispersed Poisson distribution 
 
 ## Supplemental Table
 
-### Sup. Table 1. Data collection.
+### Table `r table_supp_collection`. Data collection.
 \(A\) IPSCs were sorted using the 10-17 μm IFC plates with the staining of the pluripotency marker, TRA1-60.
 Single cell occupancy is the percentage of occupied capture sites containing one single cell.
 The average cDNA concentration was measured by the HT DNA high sensitivity LabChip (Caliper).
 (B) To obtain 3 million good quality raw reads and the average of 200,000 molecules per cells, the 96 single cell libraries from one C1 plate were pooled and sequenced in 3 HiSeq lanes.
 The pooled samples were assigned across the four 8-lane flowcells.
 
-### Sup. Table 2. Genes associated with inter-individual differences in regulatory noise
+### Table `r table_noisygene`. Genes associated with inter-individual differences in regulatory noise
 List of genes that we classified the estimates of regulatory noise as significantly different across individuals (empirical permutation *P* < 10^-5^). There are total 330 genes.
 
-### Sup. Table 3. Gene ontology analysis of the genes associated with inter-individual differences in regulatory noise
+### Table `r table_GO`. Gene ontology analysis of the genes associated with inter-individual differences in regulatory noise
 List of the GO with *P* < 0.05.

--- a/paper/methods.Rmd
+++ b/paper/methods.Rmd
@@ -21,12 +21,12 @@ Single cell loading and capture were performed following the Fluidigm manual "Us
 Briefly, 30 ul of C1 Suspension Reagent was added to a 70-ul aliquot of ~17,500 cells.
 Five ul of this cell mix were loaded onto 10-17 um C1 Single-Cell Auto Prep IFC microfluidic chip (Fluidigm), and the chip was then processed on a C1 instrument using the cell-loading script according to the manufacturer's instructions.
 Using the standard staining script, the iPSCs were stained with StainAlive TRA-1-60 Antibody (Stemgent, PN 09-0068).
-The capture efficiency and TRA-1-60 staining were then inspected using the EVOS FL Cell Imaging System (ThermoFisher)(`r table_supp_collection`A).
+The capture efficiency and TRA-1-60 staining were then inspected using the EVOS FL Cell Imaging System (ThermoFisher)(Table `r table_supp_collection`A).
 
 Immediately after imaging, reverse transcription and cDNA amplification were performed in the C1 system using the SMARTer PCR cDNA Synthesis kit (Clontech) and the Advantage 2 PCR kit (Clontech) according to the instructions in the Fluidigm user manual with minor changes to incorporate UMI labeling [@Islam2014]. 
 Specifically, the reverse transcription primer and the 1:50,000 Ambion® ERCC Spike-In Mix1 (Life Tech) were added to the lysis buffer, and the template-switching RNA oligos which contain the UMI (5-bp random sequence) were included in the reverse transcription mix [@Islam2011; @Islam2012; @Islam2014]. 
 When the run finished, full-length, amplified, single-cell cDNA libraries were harvested in a total of approximately 13 ul C1 Harvesting Reagent and quantified using DNA High Sensitivity LabChip (Caliper). 
-The average yield of samples per C1 plate ranged from 1.26-1.88 ng per microliter (`r table_supp_collection`A).
+The average yield of samples per C1 plate ranged from 1.26-1.88 ng per microliter (Table `r table_supp_collection`A).
 A bulk sample, a 40 ul aliquot of ~10,000 cells, was collected in parallel with each C1 chip using the same reaction mixes following the C1 protocol of "Tube Controls with Purified RNA" (PN 100-7168, Appendix A).
 
 For sequencing library preparation, tagmentation and isolation of 5' fragments were performed according to the UMI protocol [@Islam2014].
@@ -39,7 +39,7 @@ All of the 18 bulk libraries were then pooled and labelled as the "bulk" for seq
 ### Illumina high-throughput sequencing
 
 Single-cell RNA-seq libraries generated from 96 single cells (namely, one C1 microfluidic prep) were pooled and then sequenced in three lanes on an Illumina Hiseq 2500 instrument using the PCR primer (C1-P1-PCR-2: Bio-GAATGATACGGCGACCACCGAT) as the read 1 primer and the Tn5 adapter (C1-Tn5-U: PHO-CTGTCTCTTATACACATCTGACGC) as the index read primer following the UMI protocol [@Islam2014].
-The master mixes, one mix with all the bulk samples and nine mixes corresponding to the three replicates for the three individuals, were sequenced across four flowcells using a design aimed to minimize the introduction of technical batch effects (`r table_supp_collection`B). 
+The master mixes, one mix with all the bulk samples and nine mixes corresponding to the three replicates for the three individuals, were sequenced across four flowcells using a design aimed to minimize the introduction of technical batch effects (Table `r table_supp_collection`B). 
 Single-end 100 bp reads were generated along with 8-bp index reads corresponding to the cell-specific barcodes. 
 We did not observe any obvious technical effects due to sequencing lane or flow cell that confounded the inter-individual and inter-replicate comparisons.
 
@@ -128,7 +128,7 @@ Each data point in Figure `r fig_main_subsample` represents the mean of 10 rando
 The standard error of the mean (sem) is also included.
 We split the genes by expression level (6,097 genes each) to highlight that most of the improvement with increased sequencing depth and number of cells is driven by the estimates of the lower half of expressed genes.
 The data shown is for individual NA19239, but the results were consistent for individuals NA19098 and NA19101.
-Only high quality single cells (`r table_qualitycell`) were included in this analysis.
+Only high quality single cells (Table `r table_qualitycell`) were included in this analysis.
 
 ### Cell cycle phase classification
 

--- a/paper/results.Rmd
+++ b/paper/results.Rmd
@@ -13,7 +13,7 @@ We added ERCC spike-in controls to each sample, and used 5-bp random sequence UM
 For each of the YRI lines, we performed three independent C1 collections.
 This study design (Figure `r fig_main_qc`A) allows us to estimate error and variability associated with the technical processing of the samples, independently from the biological variation across single cells of different individuals.  
 
-The three C1 replicates of each individual were collected on different dates using cell cultures of different passage numbers (`r table_supp_collection`A).
+The three C1 replicates of each individual were collected on different dates using cell cultures of different passage numbers (Table `r table_supp_collection`A).
 Each replicate of C1 collection was accompanied by procesing of a matching bulk sample using the same reagents.
 This property of the study design allowed us to globally characterize the regulatory variation between replicates of the same cell culture, as well as to estimate how well scRNA-seq data can recapitulate the RNA-seq results from population bulk samples.
 
@@ -53,7 +53,7 @@ Visual inspection of the C1 microfluidic plate is an important quality control s
 We therefore filtered data from the remaining samples based on the number of total mapped reads, the percentage of unmapped reads, the percentage of ERCC spike-in reads, and the number of genes detected (Figure `r fig_main_qc`B-E).
 We chose data-driven inclusion cutoffs for each metric, based on the 95th percentile of the respective distributions for the 21 libraries that were amplified from samples that did not include a cell based on visual inspection (Figure `r fig_supp_qc`C-F).
 Using this approach, we identified and removed data from 15 additional samples that were classified as originating from a single cell based on visual inspection, but whose data were more consistent with a multiple-cell origin based on the number of total molecules, the concentration of cDNA amplicons, and the read-to-molecule conversion efficiency (defined as the number of total molecules divided by the number of total reads; Figure `r fig_supp_lda`).
-At the conclusion of these quality control analyses and exclusion steps, we retained data from `r nrow(anno_filter)` high quality samples, which correspond, with reasonable confidence, to `r nrow(anno_filter)` single cells, across eight replicates from three individuals (`r table_qualitycell`).
+At the conclusion of these quality control analyses and exclusion steps, we retained data from `r nrow(anno_filter)` high quality samples, which correspond, with reasonable confidence, to `r nrow(anno_filter)` single cells, across eight replicates from three individuals (Table `r table_qualitycell`).
 
 Our final quality check focused on the different properties of sequencing read and molecule count data.
 We considered data from the 564 high quality samples and compared gene specific counts of sequencing read and molecules.
@@ -160,6 +160,6 @@ We found similar results when we considered data from all single cells, regardle
 
 Next, we identified genes whose estimated regulatory noise (based on the adjusted CV) is significantly different between individuals (using median of absolute deviation to quantify the degree of dissimilarity between individuals).
 For the purpose of this analysis, we only included data from cells in which the gene was detected as expressed.
-Based on permutations (Figure `r fig_supp_permutation`), we classified the estimates of regulatory noise of 330 genes as significantly different across individuals (empirical permutation *P* < 10^-5^; Figure `r fig_main_noisygene` for examples; `r table_noisygene` for gene list).
-These 330 genes are enriched for genes involved in protein translation, protein disassembly, and various biosynthetic processes (`r table_GO`).
+Based on permutations (Figure `r fig_supp_permutation`), we classified the estimates of regulatory noise of 330 genes as significantly different across individuals (empirical permutation *P* < 10^-5^; Figure `r fig_main_noisygene` for examples; Table `r table_noisygene` for gene list).
+These 330 genes are enriched for genes involved in protein translation, protein disassembly, and various biosynthetic processes (Table `r table_GO`).
 Interestingly, among the genes whose regulatory noise estimates differ between individuals, we found two highly expressed pluripotency genes, *DNMT3B* and *NR6A1* (Figure `r fig_supp_plurigene`).

--- a/paper/results.Rmd
+++ b/paper/results.Rmd
@@ -148,7 +148,7 @@ Gene dropout is the term used to describe the lack of molecule representation of
 To investigate the effects of gene dropouts, we considered the association between the proportion of cells in which a given gene is undetected (namely, the gene-specific dropout rate), the average gene expressing level, and estimates of gene expression noise.
 Across all genes, the median gene-specific dropout was 22 percent of cells.
 We found significant individual differences (LRT; *P* < 10^-5^) in gene-specific dropout rates between individuals in more than 10% (1,214 of `r format(sum(grepl("ENSG", rownames(molecules_filter))), big.mark = ",")`) of expressed endogenous genes.
-As expected, the expression levels, and the estimated variation in expression levels across cells, are both associated with gene-specific dropout rates (Sup. Figure `r fig_supp_dropout`A and `r fig_supp_dropout`B, respectively).
+As expected, the expression levels, and the estimated variation in expression levels across cells, are both associated with gene-specific dropout rates (Figure `r fig_supp_dropout`A and `r fig_supp_dropout`B, respectively).
 However, importantly, adjusted CVs are not associated with gene dropout rates (Spearman's correlation = 0.04; Figure `r fig_supp_dropout`C), indicating that – at the resolution afforded by our RNA sequencing depth - adjusted CV measurements are not confounded by the dynamic range of single-cell gene expression levels.
 
 We thus estimated mean expression levels and regulatory noise (using adjusted CV) for each gene, by either including (Figure `r fig_main_noise`A) or excluding (Figure `r fig_main_noise`B) samples in which the gene was not detected/expressed.


### PR DESCRIPTION
Some references to supplemental figures had a preceding "Sup." while others did not. The tables always had Sup. and were handled differently than the figure naming. I standardized everything so that both the management and appearance of supplemental figures and tables is concordant.
